### PR TITLE
Add missing ddt dep

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,6 +7,6 @@ tox==3.14.0
 coverage==4.5.4
 Sphinx==1.8.5
 twine==1.14.0
-
+ddt
 pytest==4.6.5
 pytest-runner==5.1

--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,9 @@ with open('HISTORY.rst') as history_file:
 
 requirements = ['numpy']
 
-setup_requirements = []
+setup_requirements = ['pytest-runner']
 
-test_requirements = []
+test_requirements = ['ddt', 'pytest']
 
 setup(
     author="Patrick Boettcher",


### PR DESCRIPTION
CI fails since ddt is missing in requirements.