### PR TITLE
Create callback-based-shape used to shape models

### DIFF
--- a/broni/__init__.py
+++ b/broni/__init__.py
@@ -71,16 +71,12 @@ class Trajectory:
 
     @property
     def cartesian(self):
-        return np.array((self._x,
-                         self._y,
-                         self._z)).T * self._x.unit
+        return np.array((self.x,
+                         self.y,
+                         self.z)).T * self.x.unit
 
     def _spherical(self):
         if self._r is None:
-            # xy = self._x ** 2 + self._y ** 2
-            # self._r = np.sqrt(xy + self._z ** 2)
-            # self._lon = np.arctan2(np.sqrt(xy), self._z)
-            # self._lat = np.arctan2(self._y, self._x)
             self._r, self._lat, self._lon = cartesian_to_spherical(self._x, self._y, self._z)
 
 

--- a/broni/shapes/callback.py
+++ b/broni/shapes/callback.py
@@ -4,6 +4,7 @@ from .. import Trajectory
 from functools import partial
 import numpy as np
 from astropy.units.quantity import Quantity
+from astropy.constants import R_earth
 
 from typing import Callable
 
@@ -43,7 +44,7 @@ class SphericalBoundary(Shape):
         self._cb = partial(callback, **kwargs)
 
     def intersect(self, trajectory: Trajectory):
-        distances = trajectory.r - self._cb(trajectory.lon, trajectory.lat)[0]
+        distances = trajectory.r - self._cb(trajectory.lon, trajectory.lat)[0] * R_earth
 
         return (distances >= self._lower if self._lower is not None else True) & \
                (distances <= self._upper if self._upper is not None else True)

--- a/broni/shapes/callback.py
+++ b/broni/shapes/callback.py
@@ -1,0 +1,78 @@
+from . import Shape
+from .. import Trajectory
+
+from functools import partial
+import numpy as np
+from astropy.units.quantity import Quantity
+
+from typing import Callable
+
+
+class SphericalBoundary(Shape):
+    """
+    Calculates intersections of a trajectory with a spherical boundary.
+
+    A callback-function has to be provided which is called with theta and phi angles (as np.array)
+    and a keyword argument requesting spherical coordinates (r, thetha, phi) in return ('base'="spherical").
+
+    kwargs passed to the constructor are forwarded to the callback-function (except for the base-keyword).
+
+    Optionally an upper and/or a lower bound can be specified to define a range around the boundary. In practice
+    at least one of them should be defined - trajectory points are rarely exactly on the boundary.
+
+    lower-bound has to be less than upper-bound if upper-bound is specified. A positive  lower-bound means that
+    the selected range is actually outside the spherical object. A negative upper-bound means the range is
+    inside the object.
+    """
+
+    def __init__(self, callback: Callable,
+                 lower_bound: Quantity = None,
+                 upper_bound: Quantity = None, **kwargs):
+        if lower_bound is None and upper_bound is None:
+            raise ValueError("At least of one of lower or upper bound has to be specified.")
+
+        self._lower = lower_bound
+        self._upper = upper_bound
+
+        if self._lower is not None and self._upper is not None:
+            if self._lower > self._upper:
+                raise ValueError(
+                    f"lower-bound-value ({lower_bound}) needs to be lower than upper-bound-value ({upper_bound})")
+
+        kwargs.update({'base': 'spherical'})  # force spherical basis, overriding user's request
+        self._cb = partial(callback, **kwargs)
+
+    def intersect(self, trajectory: Trajectory):
+        distances = trajectory.r - self._cb(trajectory.lon, trajectory.lat)[0]
+
+        return (distances >= self._lower if self._lower is not None else True) & \
+               (distances <= self._upper if self._upper is not None else True)
+
+
+class Sheath(Shape):
+    """
+    Intersections of a trajectory with a sheath-object are effectively all the points which are
+    in-between two spherical-boundaries. This class does exactly that, it takes two callbacks representing
+    the inner and outer boundary, creates two SphericalBoundary-instances and finds all the corresponding points.
+
+    In addition an inner and/or an outer margin can be specified which will also find points just outside
+    the sheath within the margin.
+    """
+
+    def __init__(self,
+                 inner_callback: Callable,
+                 outer_callback: Callable,
+                 inner_margin: Quantity = 0,
+                 outer_margin: Quantity = 0,
+                 **kwargs):
+        if inner_margin is None or outer_margin is None or inner_margin < 0 or outer_margin < 0:
+            raise ValueError("The margins have to be larger or equal to zero if specified.")
+
+        self.inner_model = SphericalBoundary(inner_callback, -inner_margin, None, **kwargs)
+        self.outer_model = SphericalBoundary(outer_callback, None, outer_margin, **kwargs)
+
+    def intersect(self, trajectory: Trajectory):
+        inner_mask = self.inner_model.intersect(trajectory)
+        outer_mask = self.outer_model.intersect(trajectory)
+
+        return np.logical_and(inner_mask, outer_mask)

--- a/examples/main-magneto.py
+++ b/examples/main-magneto.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+
+
+from broni.shapes.primitives import Cuboid
+from broni.shapes.callback import SphericalBoundary, Sheath
+import broni
+
+from astropy.units import km
+from astropy.constants import R_earth
+
+import datetime
+import matplotlib.pyplot as plt
+
+import numpy as np
+
+from space.models.planetary import formisano1979, mp_formisano1979, bs_formisano1979
+
+
+def cuboid_mesh(cuboid):
+    p1 = cuboid.p1.value
+    p2 = cuboid.p2.value
+    p3 = cuboid.p3.value
+    p4 = cuboid.p4.value
+
+    X = [[p1[0], p2[0], p2[0], p1[0], p1[0]],
+         [p1[0], p2[0], p2[0], p1[0], p1[0]],
+         [p1[0], p2[0], p2[0], p1[0], p1[0]],
+         [p1[0], p2[0], p2[0], p1[0], p1[0]]]
+
+    Y = [[p1[1], p1[1], p3[1], p3[1], p1[1]],
+         [p1[1], p1[1], p3[1], p3[1], p1[1]],
+         [p1[1], p1[1], p1[1], p1[1], p1[1]],
+         [p3[1], p3[1], p3[1], p3[1], p3[1]]]
+
+    Z = [[p1[2], p1[2], p1[2], p1[2], p1[2]],
+         [p4[2], p4[2], p4[2], p4[2], p4[2]],
+         [p1[2], p1[2], p4[2], p4[2], p1[2]],
+         [p1[2], p1[2], p4[2], p4[2], p1[2]]]
+
+    return np.array((X, Y, Z), dtype=float)
+
+
+class SphereModel:
+    def __init__(self, radius: float):
+        self.r = radius
+
+    def __call__(self, theta, phi, **kwargs):
+        base = kwargs.get('base', 'catersian')
+
+        if base == 'spherical':
+            return np.full(theta.shape, self.r.to('km').value) * km, theta, phi
+        else:
+            return self.r * np.sin(theta) * np.cos(phi), \
+                   self.r * np.sin(theta) * np.sin(phi), \
+                   self.r * np.cos(theta)
+
+
+if __name__ == '__main__':
+    coord_sys = "gse"
+
+    X = np.arange(-200000, 200000, 10).flatten() * km
+
+    orbit = broni.Trajectory(np.zeros(X.shape) * km,
+                             X,
+                             np.zeros(X.shape) * km,
+                             np.arange(0, len(X)),
+                             coordinate_system=coord_sys)
+
+    boundary_model = SphericalBoundary(mp_formisano1979, 0 * R_earth, 1 * R_earth)
+    # boundary_model = Sheath(mp_formisano1979, bs_formisano1979)
+
+    # boundary_model = SphericalBoundary(SphereModel(100000 * km), -1 * R_earth, 0)
+    # boundary_model = Sheath(SphereModel(100000 * km), SphereModel(110000 * km))
+
+    intervals = broni.intervals(orbit, [boundary_model])
+
+    print('found', len(intervals), 'intervals')
+    for i in sorted(intervals):
+        print('  ', i,
+              datetime.datetime.fromtimestamp(i[0]).strftime('%c'), '-',
+              datetime.datetime.fromtimestamp(i[1]).strftime('%c'), ';',
+              i[0], '-', i[1])
+
+    # plot
+    th_1d = np.linspace(0, np.pi * 0.75, 20)
+    ph_1d = np.linspace(0, 2 * np.pi, 20)
+    th, ph = np.meshgrid(th_1d, ph_1d, indexing='ij')
+
+    if boundary_model.__class__ == SphericalBoundary:
+        x, y, z = boundary_model._cb.func(th, ph)
+    else:
+        x, y, z = boundary_model.inner_model._cb.func(th, ph)
+        xb, yb, zb = boundary_model.outer_model._cb.func(th, ph)
+
+
+    def make_fig(elev=None, azim=None, limit=False):
+        fig = plt.figure()
+        ax = fig.add_subplot(projection='3d')
+
+        # msphere
+        ax.plot_surface(x, y, z, alpha=0.2, color='b')
+        # bowshock
+        if boundary_model.__class__ == Sheath:
+            ax.plot_surface(xb, yb, zb, alpha=0.3, color='r')
+
+        # orbit
+        ax.plot(orbit.x, orbit.y, orbit.z, color='r')
+
+        ax.set_xlabel('x')
+        ax.set_ylabel('y')
+        ax.set_zlabel('z')
+
+        if not None in [elev, azim]:
+            ax.view_init(elev, azim)
+
+        # intersection points
+        for i in intervals:
+            ax.plot(orbit.x[i[0]:i[1]],
+                    orbit.y[i[0]:i[1]],
+                    orbit.z[i[0]:i[1]],
+                    color='g', linewidth=3)
+            if limit:
+                ax.set_xlim3d(min(orbit.x[i[0]:i[1]]) - R_earth.value, max(orbit.x[i[0]:i[1]]) + R_earth.value)
+                ax.set_ylim3d(min(orbit.y[i[0]:i[1]]) - R_earth.value, max(orbit.y[i[0]:i[1]]) + R_earth.value)
+                ax.set_zlim3d(min(orbit.z[i[0]:i[1]]) - R_earth.value, max(orbit.z[i[0]:i[1]]) + R_earth.value)
+
+            len = np.sqrt(orbit.x[i[0]:i[1]] ** 2 + orbit.y[i[0]:i[1]] ** 2 + orbit.z[i[0]:i[1]] ** 2)
+            # print(np.min(len), np.max(len)) #np.max(len) - np.min(len) - R_earth)
+        return fig
+
+
+    make_fig(limit=False)
+    # make_fig(0, 0, False)  # zy
+    # make_fig(90, 0, False)  # yx
+    # make_fig(0, 90, False)  # xz
+
+    plt.show()

--- a/tests/test_callback_sphericial.py
+++ b/tests/test_callback_sphericial.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python
+
+import unittest
+from ddt import ddt, data, unpack
+
+import numpy as np
+from astropy.units import km
+from astropy.units.quantity import Quantity
+
+from broni.shapes.callback import SphericalBoundary, Sheath
+import broni
+
+
+class SphereModel:
+    def __init__(self, radius: Quantity):
+        self.r = radius
+
+    def __call__(self, theta, phi, **kwargs):
+        assert (kwargs['base'] == 'spherical' or kwargs['base'] == 'cartesian')
+
+        if kwargs['base'] == 'spherical':
+            return np.full(theta.shape, self.r.to('km').value) * km, theta, phi
+        # else:
+        #     return self.r * np.sin(theta) * np.cos(phi), \
+        #            self.r * np.sin(theta) * np.sin(phi), \
+        #            self.r * np.cos(theta)
+
+
+@ddt
+class TestCallbacks(unittest.TestCase):
+    def test_boundary_invalid_ctor_args_no_lower_or_upper_bound_given(self):
+        with self.assertRaises(ValueError):
+            assert SphericalBoundary(SphereModel(1))
+
+    def test_boundary_invalid_ctor_args_lower_bound_greater_than_upper_bound(self):
+        with self.assertRaises(ValueError):
+            assert SphericalBoundary(SphereModel(1), 1, 0)
+
+    def test_boundary_invalid_ctor_args_upper_bound_greater_than_lower_bound(self):
+        with self.assertRaises(ValueError):
+            assert SphericalBoundary(SphereModel(1), 0, -1)
+
+    def test_sheath_invalid_ctor_args_margin_inner_none(self):
+        with self.assertRaises(ValueError):
+            assert Sheath(SphereModel(1), SphereModel(2), None, 1)
+
+    def test_sheath_invalid_ctor_args_margin_outer_none(self):
+        with self.assertRaises(ValueError):
+            assert Sheath(SphereModel(1), SphereModel(2), 1, None)
+
+    def test_sheath_invalid_ctor_args_margin_inner_less_zero(self):
+        with self.assertRaises(ValueError):
+            assert Sheath(SphereModel(1), SphereModel(2), -1, 1)
+
+    def test_sheath_invalid_ctor_args_margin_outer_less_zero(self):
+        with self.assertRaises(ValueError):
+            assert Sheath(SphereModel(1), SphereModel(2), 1, -1)
+
+    def test_boundary_kwargs_forwarding_and_creation(self):
+        def func(theta, phi, **kwargs):
+            assert ('test' in kwargs)
+            assert (kwargs['test'] == 'value')
+
+            assert ('base' in kwargs)
+            assert (kwargs['base'] == 'spherical')
+
+            return np.zeros(theta.shape), theta, phi
+
+        shape = SphericalBoundary(func, 0, test='value')
+        shape.intersect(broni.Trajectory([] * km, [] * km, [] * km, [], 'gse'))
+
+    @data(
+        ((1, -0.5, 0.5), [[-1, 0, 0], [0, 0, 0], [1, 0, 0], [2, 0, 0]], [True, False, True, False]),
+        ((1, None, 0.5), [[-1, 0, 0], [0, 0, 0], [1, 0, 0], [2, 0, 0]], [True, True, True, False]),
+        ((1, -0.5, None), [[-1, 0, 0], [0, 0, 0], [1, 0, 0], [2, 0, 0]], [True, False, True, True]),
+        ((1, -10, 10), [[-1, 0, 0], [0, 0, 0], [1, 0, 0], [2, 0, 0]], [True, True, True, True]),
+    )
+    @unpack
+    def test_boundary_with_sphere_model_intersections(self, model, trajectory, expected):
+        shape = SphericalBoundary(SphereModel(model[0] * km),
+                                  model[1] * km if model[1] is not None else None,
+                                  model[2] * km if model[2] is not None else None)
+
+        td = np.array(trajectory) * km
+
+        np.testing.assert_array_equal(
+            shape.intersect(
+                broni.Trajectory(
+                    td[:, 0], td[:, 1], td[:, 2],
+                    np.arange(0, len(trajectory)),
+                    "gse")
+            ),
+            np.array(expected))
+
+    @data(
+        ((1, 2, 0, 0), [[-1, 0, 0], [0, 0, 0], [1, 0, 0], [2, 0, 0]], [True, False, True, True]),
+        ((1, 1.5, 0, 0), [[-1, 0, 0], [0, 0, 0], [1, 0, 0], [2, 0, 0]], [True, False, True, False]),
+        ((1, 1.5, 1, 0), [[-1, 0, 0], [0, 0, 0], [1, 0, 0], [2, 0, 0]], [True, True, True, False]),
+        ((1, 1.5, 0, 1), [[-1, 0, 0], [0, 0, 0], [1, 0, 0], [2, 0, 0]], [True, False, True, True]),
+        ((1, 1.5, 1, 1), [[-1, 0, 0], [0, 0, 0], [1, 0, 0], [2, 0, 0]], [True, True, True, True]),
+
+        # inverse inner/outer -> nothing
+        ((1.5, 1, 0, 0), [[-1, 0, 0], [0, 0, 0], [1, 0, 0], [2, 0, 0]], [False, False, False, False]),
+    )
+    @unpack
+    def test_sheath_with_2_spheres_intersections(self, model, trajectory, expected):
+        shape = Sheath(SphereModel(model[0] * km),
+                       SphereModel(model[1] * km),
+                       model[2] * km,
+                       model[3] * km)
+
+        td = np.array(trajectory) * km
+
+        np.testing.assert_array_equal(
+            shape.intersect(
+                broni.Trajectory(
+                    td[:, 0], td[:, 1], td[:, 2],
+                    np.arange(0, len(trajectory)),
+                    "gse")
+            ),
+            np.array(expected))


### PR DESCRIPTION
Models are usually represented by function receiving,
in spherical term, theta/phi and return the distance from
the center. This commit adds two classes using these kind
of functions to be used as shapes within broni.